### PR TITLE
🛠 Bug Repair

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -233,6 +233,8 @@ aside:
     face:
     # 鼠标悬停翻转图片
     backface:
+    # 夜间模式下是否开启卡片背景颜色 true：使用背景颜色 / false：不使用背景颜色
+    darkcolor: false
   # 个性定位
   welcome:
     enable: false

--- a/layout/includes/widgets/post/postMeta.pug
+++ b/layout/includes/widgets/post/postMeta.pug
@@ -7,7 +7,7 @@
             a.post-meta-original(title="该文章为" + cc + "文章，注意版权协议")= cc
             if page.categories.data.length > 0
                 span.post-meta-categories
-                    a.post-meta-categories(href=page.categories.data[0].path)= page.categories.data[0].name
+                    a.post-meta-categories(href='/' + page.categories.data[0].path)= page.categories.data[0].name
             .tag_share
                 .post-meta__tag-list
                     each tag in page.tags.data

--- a/source/css/_widgets/_aside/flip.styl
+++ b/source/css/_widgets/_aside/flip.styl
@@ -65,5 +65,6 @@ faceback = hexo-config('aside.flip.backface')
       background url(faceback) center center no-repeat
       background-size 100%
 
-    [data-theme='dark'] #aside-content .card-widget.card-platform
-      background var(--sco-card-bg)
+if !hexo-config('aside.flip.darkcolor')
+  [data-theme='dark'] #aside-content .card-widget.card-platform
+    background var(--sco-card-bg)

--- a/source/css/_widgets/_post/meta.styl
+++ b/source/css/_widgets/_post/meta.styl
@@ -399,7 +399,6 @@
 
           span.post-meta-categories
             background-color var(--sco-white-op)
-            padding 0 .5rem
             border-radius 8px
             line-height 32px
             height 32px
@@ -417,6 +416,7 @@
               width 100%
               height 100%
               display flex
+              padding 0 .5rem
 
               &:hover
                 color var(--sco-main)

--- a/source/js/extend/covercolor/local.js
+++ b/source/js/extend/covercolor/local.js
@@ -21,7 +21,7 @@ function coverColor() {
             r = Math.floor(r / (data.length / 4 / step));
             g = Math.floor(g / (data.length / 4 / step));
             b = Math.floor(b / (data.length / 4 / step));
-            var value = "#" + r.toString(16) + g.toString(16) + b.toString(16);
+            var value = "#" + r.toString(16).padStart(2, '0') + g.toString(16).padStart(2, '0') + b.toString(16).padStart(2, '0');
             if (getContrastYIQ(value) == "light") {
                 value = LightenDarkenColor(colorHex(value), -50)
             }
@@ -30,6 +30,15 @@ function coverColor() {
             document.documentElement.style.setProperty('--sco-main-op', value + '23');
             document.documentElement.style.setProperty('--sco-main-op-deep', value + 'dd');
             document.documentElement.style.setProperty('--sco-main-none', value + '00');
+
+            var brightness = Math.round(((parseInt(r) * 299) + (parseInt(g) * 587) + (parseInt(b) * 114)) / 1000);
+            if (brightness < 125) {
+                var cardContents = document.getElementsByClassName('card-content');
+                for (var i = 0; i < cardContents.length; i++) {
+                    cardContents[i].style.setProperty('--sco-card-bg', 'var(--sco-fontcolor)');
+                }
+            }
+
             initThemeColor()
             document.getElementById("coverdiv").classList.add("loaded");
         }

--- a/source/js/extend/covercolor/local.js
+++ b/source/js/extend/covercolor/local.js
@@ -35,7 +35,7 @@ function coverColor() {
             if (brightness < 125) {
                 var cardContents = document.getElementsByClassName('card-content');
                 for (var i = 0; i < cardContents.length; i++) {
-                    cardContents[i].style.setProperty('--sco-card-bg', 'var(--sco-fontcolor)');
+                    cardContents[i].style.setProperty('--sco-card-bg', 'var(--sco-white)');
                 }
             }
 


### PR DESCRIPTION
- 调整post-meta-categories的padding宽度，移除此父级的padding宽度，以便更好获取焦点位置。
- 修复post-meta-categories的href事件的`/`丢失导致的404跳转
- 修复侧边栏公众号的夜间背景颜色丢失问题，并新增配置项进行控制是否在夜间模式使用卡片背景颜色
- 修复本地取色时，图片过于深色导致的色值缺失问题，并优化色值为深色（近黑色）时，将个人卡片`card-info`的字体颜色`--sco-card-bg`赋值为相对色（继承--sco-white色值）